### PR TITLE
Added more flexibility in merging fastq files with different name patterns

### DIFF
--- a/README.html
+++ b/README.html
@@ -427,16 +427,17 @@ summary {
 <h3>Retrieving data from Illumina basespace <em>via</em> command line (optional)</h3>
 <p>Data in form of <code>*.fastq</code> files can be manually downloaded from the basespace website on MacOS or Windows. For Linux systems, only the command line option is available via Illumina’s basespace client <code>bs-cp</code>. Files are in Illumina’s proprietary format. Execute the following line in a terminal and replace <code>&lt;your-run-ID&gt;</code> with the number you will find in the URL of your browser. For example, log in to basespace, navigate to <code>runs</code>, select a sequencing run and copy the ID you find in the URL: <code>https://basespace.illumina.com/run/200872678/details</code>.</p>
 <pre><code>bs-cp -v https://basespace.illumina.com/Run/&lt;your-run-ID&gt; /your/target/directory/</code></pre>
-<p>The data must then be converted to <code>*.fastq</code> (plain text) files using Illumina’s <code>bcl2fastq</code> tool. If it complains about indices being too similar to demultiplex, the command has to be executed with option <code>--barcode-mismatches 0</code>.</p>
+<p>The data must then be converted to <code>*.fastq</code> (plain text) files using Illumina’s <code>bcl2fastq</code> tool. It is recommended to run it with option <code>--no-lane-splitting</code> in order to obtain one file per sample, instead of several files subdivided by lane. If it complains about indices being too similar to demultiplex, the option <code>--barcode-mismatches 0</code> can be added.</p>
 <pre><code>cd /your/target/directory/
-bcl2fastq</code></pre>
-<p>The gzipped <code>*.fastq.gz</code> files will be stored in <code>data/projects/example/Data/Intensities/BaseCalls/</code>. To merge several lanes or replicates of the same sample into a new <code>*.fastq.gz</code> file, run the following script. Input and output folder can be specified with the following optional parameters (the default is current directory <code>./</code>):</p>
+bcl2fastq --no-lane-splitting</code></pre>
+<p>The gzipped <code>*.fastq.gz</code> files will be stored in <code>./Data/Intensities/BaseCalls/</code>. To merge replicates of the same sample into a new <code>*.fastq.gz</code> file, run the following script. The script merges files matching a certain <code>pattern</code> into a single new file. Input and output folder can be specified with optional parameters (the default is current directory <code>./</code>). New file names are truncated to the part preceding the variable pattern (all characters trailing the pattern are ignored).</p>
 <ul>
 <li><code>input_dir</code> - input directory</li>
 <li><code>output_dir</code> - - output directory</li>
 <li><code>file_ext</code> - file extension of the target files (default: <code>fastq.gz</code>)</li>
+<li><code>pattern</code> - all files matching this pattern will be merged (default: <code>_L00[1-4]_</code>)</li>
 </ul>
-<pre><code>source/merge_fastq_files.sh --input_dir data/projects/example/ --output_dir data/projects/example/</code></pre>
+<pre><code>source/merge_fastq_files.sh --input_dir data/fastq/ --output_dir data/fastq/ --pattern _R.</code></pre>
 </div>
 <div id="input-files" class="section level3">
 <h3>Input files</h3>

--- a/README.md
+++ b/README.md
@@ -18,21 +18,22 @@ For Linux systems, only the command line option is available via Illumina's base
 bs-cp -v https://basespace.illumina.com/Run/<your-run-ID> /your/target/directory/
 ```
 
-The data must then be converted to `*.fastq` (plain text) files using Illumina's `bcl2fastq` tool. If it complains about indices being too similar to demultiplex, the command has to be executed with option `--barcode-mismatches 0`.
+The data must then be converted to `*.fastq` (plain text) files using Illumina's `bcl2fastq` tool. It is recommended to run it with option `--no-lane-splitting` in order to obtain one file per sample, instead of several files subdivided by lane. If it complains about indices being too similar to demultiplex, the option `--barcode-mismatches 0` can be added.
 
 ```
 cd /your/target/directory/
-bcl2fastq
+bcl2fastq --no-lane-splitting
 ```
 
-The gzipped `*.fastq.gz` files will be stored in `data/projects/example/Data/Intensities/BaseCalls/`. To merge several lanes or replicates of the same sample into a new `*.fastq.gz` file, run the following script. Input and output folder can be specified with the following optional parameters (the default is current directory `./`):
+The gzipped `*.fastq.gz` files will be stored in `./Data/Intensities/BaseCalls/`. To merge replicates of the same sample into a new `*.fastq.gz` file, run the following script. The script merges files matching a certain `pattern` into a single new file. Input and output folder can be specified with optional parameters (the default is current directory `./`). New file names are truncated to the part preceding the variable pattern (all characters trailing the pattern are ignored).
 
 - `input_dir` - input directory
 - `output_dir` - - output directory
 - `file_ext` - file extension of the target files (default: `fastq.gz`)
+- `pattern` - all files matching this pattern will be merged (default: `_L00[1-4]_`)
 
 ```
-source/merge_fastq_files.sh --input_dir data/projects/example/ --output_dir data/projects/example/
+source/merge_fastq_files.sh --input_dir data/fastq/ --output_dir data/fastq/ --pattern _R.
 ```
 
 ### Input files

--- a/source/merge_fastq_files.sh
+++ b/source/merge_fastq_files.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 #
-# Script to merge gzipped sequencing result files ("fastq.gz") for different 
-# lanes into one master file
-# based on an example on https://medium.com/ngs-sh/merging-illumina-lanes-with-a-bash-script-112e0e0e0224
+# Script to merge gzipped sequencing result files ("fastq.gz") (like, different 
+# lanes) into one master file.
+# Based on an example on https://medium.com/ngs-sh/merging-illumina-lanes-with-a-bash-script-112e0e0e0224
 # by Andrea Telatin 2017, Bash Training for Bioinformatics, Quadram Institute
 
 # optional input parameters
 input_dir=${input_dir:-"./"}
 output_dir=${output_dir:-"./"}
-file_ext=${file_ext:-"fastq.gz"}
+file_ext=${file_ext:-".fastq.gz"}
+pattern=${pattern:-"_L00[1-4]_"}
 
 # assign optional parameters that were passed with "--"
 while [ $# -gt 0 ]; do
@@ -32,7 +33,6 @@ done
 
 # make list of target files
 filenames=(`ls ${input_dir} | grep ${file_ext}`)
-#echo ${filenames[@]}
 echo "Input files matching pattern: ${#filenames[@]}"
 if [ ${#filenames[@]} == 0 ]; then
   echo "Found no files to process. Exiting."
@@ -42,9 +42,7 @@ fi
 # loop through target files and merge to new files
 for sample_file in ${filenames[@]};
 do
-  sample_name=$(basename "$sample_file"   | sed -e "s#_S[0-9]*_L00[1-4]_R[1-2]_001.${file_ext}##")
-  sample_index=$(basename "$sample_file"  | grep -o  "_S[0-9]*_L00[1-4]_R[1-2]_001.${file_ext}" | grep -o "_S[0-9]*")
-  sample_strand=$(basename "$sample_file" | grep -o  "_S[0-9]*_L00[1-4]_R[1-2]_001.${file_ext}" | grep -o "_R[1-2]")
-  echo " > Adding $sample_file to ${sample_name}${sample_index}${sample_strand}.${file_ext}";
-  cat ${input_dir}/$sample_file >> ${output_dir}/${sample_name}${sample_index}${sample_strand}.${file_ext};
+  sample_name=$(basename "$sample_file" | sed -e "s#${pattern}${file_ext}##")
+  echo " > Adding $sample_file to ${sample_name}${file_ext}";
+  cat ${input_dir}/$sample_file >> ${output_dir}/${sample_name}${file_ext};
 done


### PR DESCRIPTION
The previous script was tuned towards merging different `fastq.gz` files for each lane of a seq chip. Since lane splitting can be avoided with the `bcl2fastq` tool, the script was generalized to merge an arbitrary combination of files/names into a single file.